### PR TITLE
Update Elixir snippets for embedded Eex

### DIFF
--- a/snippets/eelixir.json
+++ b/snippets/eelixir.json
@@ -1,30 +1,37 @@
 {
-    "%": {
-        "prefix": "%",
-        "body": "<% $0 %>"
+    "ee": {
+        "prefix": "ee",
+        "body": "<% $0 %>",
+        "description": "Embedded Elixir tag"
     },
-    "%=": {
-        "prefix": "%=",
-        "body": "<%= $0 %>"
+    "eee": {
+        "prefix": "eee",
+        "body": "<%= $0 %>",
+        "description": "Embedded Elixir tag with ="
     },
     "gettext": {
         "prefix": "gt",
-        "body": "<%= gettext(\"$0\") %>"
+        "body": "<%= gettext(\"$0\") %>",
+        "description": "gettext: i18n and l10n for Elixir"
     },
     "for": {
         "prefix": "for",
-        "body": ["<%= for ${1:item} <- ${2:items} do %>", "  $0", "<% end %>"]
+        "body": ["<%= for ${1:item} <- ${2:items} do %>", "  $0", "<% end %>"],
+        "description": "List comprehension inside of an Eex tag"
     },
     "if": {
         "prefix": "if",
-        "body": ["<%= if ${1} do %>", "  $0", "<% end %>"]
+        "body": ["<%= if ${1} do %>", "  $0", "<% end %>"],
+        "description": "If statement inside of an Eex tag"
     },
     "ife": {
         "prefix": "ife",
-        "body": ["<%= if ${1} do %>", "  $2", "<% else %>", "  $0", "<% end %>"]
+        "body": ["<%= if ${1} do %>", "  $2", "<% else %>", "  $0", "<% end %>"],
+        "description": "If-else statement inside of an Eex tag"
     },
     "lin": {
         "prefix": "lin",
-        "body": "<%= link \"${1:Submit}\", to: ${2:\"/users\"}, method: ${3::delete} %>"
+        "body": "<%= link \"${1:Submit}\", to: ${2:\"/users\"}, method: ${3::delete} %>",
+        "description": "Link inside of an Eex tag"
     }
 }


### PR DESCRIPTION
It's easier to type the `e` than the `%` sign.

This change was also accompanied by a [change](https://github.com/TheDDMbassy/kickstart.nvim/commit/bcb57c5adf959998010bcec19e1a3c063a4fce99) to my neovim config to stop loading each of these Elixir & EElixir snippets twice.